### PR TITLE
Add missing New keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Have a look at the [examples folder](https://github.com/Neamar/featureless-job-q
 ### Constructor
 ```js
 var FJQ = require('featureless-job-queue')
-var fjq = FJQ({redisUrl: redisUrl})
+var fjq = new FJQ({redisUrl: redisUrl})
 ```
 
 The constructor accepts two important options:
@@ -44,7 +44,7 @@ Other options are documented lower in this README, where it makes sense to intro
 ### Process jobs
 ```js
 var FJQ = require('featureless-job-queue')
-var fjq = FJQ({redisUrl: redisUrl})
+var fjq = new FJQ({redisUrl: redisUrl})
 
 // Number of workers to run at the same time, will default to 1
 var concurrency = 40
@@ -62,7 +62,7 @@ This function will return an [`async.queue`](https://caolan.github.io/async/docs
 ### Queue jobs
 ```js
 var FJQ = require('featureless-job-queue')
-var fjq = FJQ({redisUrl: redisUrl})
+var fjq = new FJQ({redisUrl: redisUrl})
 
 // job can be any valid Js structure.
 // Try to keep it as small as possible since it will transit across the network and be fulyl stored in Redis


### PR DESCRIPTION
Examples in the readme didn't have the new keyword, this caused the following issues

```
C:\Users\PsyKzz\Desktop\lol-game-scraping\node_modules\featureless-job-queue\lib\index.js:23
  this.options = options;
               ^

TypeError: Cannot set property 'options' of undefined
    at FJQ (C:\Users\PsyKzz\Desktop\lol-game-scraping\node_modules\featureless-job-queue\lib\index.js:23:16)
    at Object.<anonymous> (C:\Users\PsyKzz\Desktop\lol-game-scraping\index.js:10:11)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
    at startup (bootstrap_node.js:149:9)
```

This should update those example to minimise future mistakes